### PR TITLE
Allow empty MQTT prefix

### DIFF
--- a/custom_components/openmower/config_flow.py
+++ b/custom_components/openmower/config_flow.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_PREFIX, default="openmower"): str,
+        vol.Optional(CONF_PREFIX, default="openmower"): str,
         vol.Optional(CONF_LATITUDE): float,
         vol.Optional(CONF_LONGITUDE): float,
     }


### PR DESCRIPTION
Mowgli docker currently has no prefix so this should not be required. It needs to be added in the future to clean up the messages but until then, this would make the integration compatible. 